### PR TITLE
Add shine effect to poll list items

### DIFF
--- a/polls/static/polls/style.css
+++ b/polls/static/polls/style.css
@@ -27,6 +27,9 @@ li {
   box-sizing: border-box;
   text-align: center;
 
+  position: relative;
+  cursor: pointer;
+
   background: linear-gradient(
     135deg,
     rgba(117, 114, 117, 0.9) 0%,
@@ -46,16 +49,39 @@ li {
 li:hover {
   transform: translateY(-4px);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.12),
-              0 3px 6px rgba(0, 0, 0, 0.10);
+              0 3px 6px rgba(0, 0, 0, 0.10),
+              0 0 8px rgb(255, 102, 199);
+}
+
+li::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    120deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.4) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: shine 2s infinite;
+  pointer-events: none;
+}
+
+@keyframes shine {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
 }
 
 li a {
-  color: white;
+  color: rgb(255, 102, 199);
   text-decoration: none;
   font: 2em sans-serif;
 }
 
-li a:hover {
-  color: rgb(255, 102, 199);
-}
+/* removed hover rule as color now matches default */
 

--- a/polls/templates/polls/index.html
+++ b/polls/templates/polls/index.html
@@ -4,7 +4,7 @@
 {% if latest_question_list %}
     <ul>
     {% for question in latest_question_list %}
-        <li><a href="{% url 'polls:detail' question.id %}">{{ question.question_text }}</a></li>
+        <li class="poll-card"><a href="{% url 'polls:detail' question.id %}">{{ question.question_text }}</a></li>
         
     {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- style poll list items with a shiny hover animation
- give each poll `<li>` a class for styling

## Testing
- `python manage.py test polls` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685999cd12e8832c8417cecce3cdff77